### PR TITLE
Parameterizing protocol so we can use https instead of http

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -2,8 +2,9 @@ var express = require('express');
 var router = express.Router();
 
 /* GET home page. */
-router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Orders', captureOrderService: "http://"+process.env.CAPTUREORDERSERVICEIP+"/v1/order" });
+router.get('/', function (req, res, next) {
+  const serviceUrl = process.env.CAPTUREORDERSERVICEURL || "http://" + process.env.CAPTUREORDERSERVICEIP;
+  res.render('index', { title: 'Orders', captureOrderService: serviceUrl + "/v1/order" });
 });
 
 module.exports = router;


### PR DESCRIPTION
I added an environment variable to override protocol so we can deploy the api with HTTPS and get rid of the mixed content errors