### PR TITLE
Simple fix for cross origin HTTPS / TLS error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:10-alpine
 ENV NODE_ENV production
 WORKDIR /usr/src/app
 COPY ["package.json", "npm-shrinkwrap.json*", "./"]

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,7 +3,7 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Orders', captureOrderService: "http://"+process.env.CAPTUREORDERSERVICEIP+"/v1/order" });
+  res.render('index', { title: 'Orders', captureOrderService: "//"+process.env.CAPTUREORDERSERVICEIP+"/v1/order" });
 });
 
 module.exports = router;


### PR DESCRIPTION
Fixes the error when the frontend & captureorder are running on HTTPS, by simply using a protocol relative URL https://www.paulirish.com/2010/the-protocol-relative-url/

Also updates Node.js version to 10.x, as 6.x is end of life